### PR TITLE
feat: Add community.lexicon.attestation.publicKey

### DIFF
--- a/community/lexicon/attestation/publicKey.json
+++ b/community/lexicon/attestation/publicKey.json
@@ -1,0 +1,49 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.attestation.publicKey",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record attesting ownership of a public key",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "attestedAt",
+          "publicKey",
+          "type"
+        ],
+        "properties": {
+          "attestedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "The date and time the public key was attested"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of public key",
+            "knownValues": [
+              "ed25519"
+            ]
+          },
+          "publicKey": {
+            "type": "string",
+            "description": "The public key to attest to ownership of, in base64 format"
+          },
+          "revokedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "The date and time the attestation was revoked"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Tags describing the purpose of the public key, for example 'pgp' or 'e2ee'",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/community/lexicon/attestation/publicKey.json
+++ b/community/lexicon/attestation/publicKey.json
@@ -35,9 +35,10 @@
             "format": "datetime",
             "description": "The date and time the attestation was revoked"
           },
-          "tags": {
+          "purposes": {
             "type": "array",
-            "description": "Tags describing the purpose of the public key, for example 'pgp' or 'e2ee'",
+            "minLength": 1,
+            "description": "Strings describing the purpose(s) of the public key, for example 'pgp' or 'e2ee'",
             "items": {
               "type": "string"
             }

--- a/community/lexicon/attestation/publicKey.json
+++ b/community/lexicon/attestation/publicKey.json
@@ -16,8 +16,8 @@
         "properties": {
           "attestedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "The date and time the public key was attested"
+            "description": "The date and time the public key was attested",
+            "format": "datetime"
           },
           "type": {
             "type": "string",
@@ -32,16 +32,16 @@
           },
           "revokedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "The date and time the attestation was revoked"
+            "description": "The date and time the attestation was revoked",
+            "format": "datetime"
           },
           "purposes": {
             "type": "array",
-            "minLength": 1,
             "description": "Strings describing the purpose(s) of the public key, for example 'pgp' or 'e2ee'",
             "items": {
               "type": "string"
-            }
+            },
+            "minLength": 1
           }
         }
       }


### PR DESCRIPTION
Adds a new community lexicon subdomain `attestation`, with one record type `publicKey`. It has the following fields:
- `publicKey`, the base64-encoded value of the public key
- `type`, the type of public key, currently only allowed to be "ed25519"
- `attestedAt`, when the attestation was created
- `tags` (optional), an array of strings describing the purpose of the key (e.g. "e2ee")
- `revokedAt` (optional), when the attestation was revoked 